### PR TITLE
Add Span Support

### DIFF
--- a/src/KTrie/Character.cs
+++ b/src/KTrie/Character.cs
@@ -1,15 +1,8 @@
 ﻿namespace KTrie;
 
-public readonly record struct Character(char c) 
+public readonly record struct Character(char Char)
 {
-    public static Character Any => AnyCharacter.Instance;
-
-    public char Char => c;
+    public static Character Any { get; } = new();
 
     public static implicit operator Character(char c) => new(c);
-
-    private static class AnyCharacter
-    {
-        public static readonly Character Instance = new(char.MinValue);
-    }
 }

--- a/src/KTrie/Character.cs
+++ b/src/KTrie/Character.cs
@@ -1,6 +1,6 @@
 ﻿namespace KTrie;
 
-public class Character(char c)
+public readonly record struct Character(char c) 
 {
     public static Character Any => AnyCharacter.Instance;
 
@@ -8,13 +8,8 @@ public class Character(char c)
 
     public static implicit operator Character(char c) => new(c);
 
-    private class AnyCharacter : Character
+    private static class AnyCharacter
     {
-        public static readonly AnyCharacter Instance = new();
-
-        private AnyCharacter() : base(char.MinValue)
-        {
-
-        }
+        public static readonly Character Instance = new(char.MinValue);
     }
 }

--- a/src/KTrie/SpanException.cs
+++ b/src/KTrie/SpanException.cs
@@ -7,8 +7,7 @@ internal static class SpanException
 {
     public static void ThrowIfNullOrEmpty(ReadOnlySpan<char> argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {
-        // Check first before doing a string allocation
-        if (argument.IsWhiteSpace())
+        if (argument.IsEmpty)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(argument.ToString(), paramName);
         }

--- a/src/KTrie/SpanException.cs
+++ b/src/KTrie/SpanException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace KTrie;
+
+internal static class SpanException
+{
+    public static void ThrowIfNullOrEmpty(ReadOnlySpan<char> argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+        // Check first before doing a string allocation
+        if (argument.IsWhiteSpace())
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(argument.ToString(), paramName);
+        }
+    }
+}

--- a/src/KTrie/Trie.cs
+++ b/src/KTrie/Trie.cs
@@ -42,9 +42,11 @@ public sealed class Trie : ICollection<string>, IReadOnlyCollection<string>
         Count = 0;
     }
 
-    public bool Contains(string word)
+    public bool Contains(string word) => Contains(word.AsSpan());
+
+    public bool Contains(ReadOnlySpan<char> word)
     {
-        ArgumentException.ThrowIfNullOrEmpty(word);
+        SpanException.ThrowIfNullOrEmpty(word);
 
         var node = GetNode(word);
 
@@ -111,7 +113,7 @@ public sealed class Trie : ICollection<string>, IReadOnlyCollection<string>
         }
     }
 
-    internal (CharTrieNode? existingTerminalNode, CharTrieNode parent) AddNodesFromUpToBottom(string word)
+    internal (CharTrieNode? existingTerminalNode, CharTrieNode parent) AddNodesFromUpToBottom(ReadOnlySpan<char> word)
     {
         var current = _root;
 
@@ -149,10 +151,14 @@ public sealed class Trie : ICollection<string>, IReadOnlyCollection<string>
         Count++;
     }
 
-    internal IEnumerable<TerminalCharTrieNode> GetTerminalNodesByPrefix(string prefix)
+    internal IEnumerable<TerminalCharTrieNode> GetTerminalNodesByPrefix(ReadOnlySpan<char> prefix)
     {
         var node = GetNode(prefix);
+        return GetTerminalNodes(node);
+    }
 
+    private IEnumerable<TerminalCharTrieNode> GetTerminalNodes(CharTrieNode? node)
+    {
         if (node is null)
         {
             yield break;
@@ -219,7 +225,7 @@ public sealed class Trie : ICollection<string>, IReadOnlyCollection<string>
         }
     }
 
-    internal CharTrieNode? GetNode(string prefix)
+    internal CharTrieNode? GetNode(ReadOnlySpan<char> prefix)
     {
         var current = _root;
 

--- a/src/KTrie/TrieDictionary.cs
+++ b/src/KTrie/TrieDictionary.cs
@@ -64,13 +64,16 @@ public sealed class TrieDictionary<TValue>(IEqualityComparer<char>? comparer = n
 
     public IEnumerable<KeyValuePair<string, TValue>> StartsWith(string value)
     {
-        ArgumentException.ThrowIfNullOrEmpty(value);
+        return StartsWith(value.AsSpan());
+    }
 
-        return _();
+    public IEnumerable<KeyValuePair<string, TValue>> StartsWith(ReadOnlySpan<char> value)
+    {
+        SpanException.ThrowIfNullOrEmpty(value);
 
-        IEnumerable<KeyValuePair<string, TValue>> _() =>
-            _trie.GetTerminalNodesByPrefix(value)
-                .Select(t => new KeyValuePair<string, TValue>(t.Word, ((TerminalValueCharTrieNode)t).Value));
+        var nodes = _trie.GetTerminalNodesByPrefix(value);
+        
+        return nodes.Select(t => new KeyValuePair<string, TValue>(t.Word, ((TerminalValueCharTrieNode)t).Value));
     }
 
     public IEnumerable<KeyValuePair<string, TValue>> Matches(IReadOnlyList<Character> pattern)
@@ -78,11 +81,9 @@ public sealed class TrieDictionary<TValue>(IEqualityComparer<char>? comparer = n
         ArgumentNullException.ThrowIfNull(pattern);
         ArgumentOutOfRangeException.ThrowIfZero(pattern.Count);
 
-        return _();
-
-        IEnumerable<KeyValuePair<string, TValue>> _() =>
-            _trie.GetNodesByPattern(pattern).Where(n => n.IsTerminal).Cast<TerminalValueCharTrieNode>()
-                .Select(n => new KeyValuePair<string, TValue>(n.Word, n.Value));
+        return _trie.GetNodesByPattern(pattern)
+            .Where(n => n.IsTerminal).Cast<TerminalValueCharTrieNode>()
+            .Select(n => new KeyValuePair<string, TValue>(n.Word, n.Value));
     }
 
     public IEnumerable<KeyValuePair<string, TValue>> StartsWith(IReadOnlyList<Character> pattern)


### PR DESCRIPTION
Added support for `ReadOnlySpan<char>`. 

The motivation for this change is to increase efficiency in a library I am creating to break string inputs along dictionary words. For example: thebigbrownduck -> the big brown duck. 

To do this, you have to go character by character down the Trie and break the string when you reach a null node. Then recursively try with the next part. Using spans instead of substrings can be a big performance gain because there are no additional string allocations. We can just keep slicing the original input and work with `ReadOnly<char>` spans