### PR TITLE
fix: added support for strings containing `\0`

### DIFF
--- a/src/KTrie.Tests/TrieTests.cs
+++ b/src/KTrie.Tests/TrieTests.cs
@@ -222,5 +222,19 @@ public class TrieTests
         Assert.Contains("abc", trie);
     }
 
+    [Fact]
+    public void NullCharacter()
+    {
+        const string wordWithCharacter = "\0abc";
+        const string wordWithoutCharacter = "abc";
+
+        Trie trie = [wordWithCharacter, wordWithoutCharacter];
+
+        var startsWithNull = trie.StartsWith(['\0']).ToArray();
+        
+        Assert.Contains(wordWithCharacter, startsWithNull);
+        Assert.DoesNotContain(wordWithoutCharacter, startsWithNull);
+    }
+
     private static string[] GetWords() => File.ReadAllLines("TestData/vocabulary.txt");
 }

--- a/src/KTrie/Character.cs
+++ b/src/KTrie/Character.cs
@@ -1,6 +1,6 @@
 ﻿namespace KTrie;
 
-public readonly record struct Character(char Char)
+public readonly record struct Character(char? Char)
 {
     public static Character Any { get; } = new();
 

--- a/src/KTrie/Trie.cs
+++ b/src/KTrie/Trie.cs
@@ -253,9 +253,9 @@ public sealed class Trie : ICollection<string>, IReadOnlyCollection<string>
 
             if (index == pattern.Count - 1)
             {
-                if (pattern[index] != Character.Any)
+                if (pattern[index].Char is {} ch)
                 {
-                    var n = GetChildNode(node, pattern[index].Char);
+                    var n = GetChildNode(node, ch);
 
                     if (n is not null)
                     {
@@ -272,9 +272,9 @@ public sealed class Trie : ICollection<string>, IReadOnlyCollection<string>
             }
             else
             {
-                if (pattern[index] != Character.Any)
+                if (pattern[index].Char is {} ch)
                 {
-                    var n = GetChildNode(node, pattern[index].Char);
+                    var n = GetChildNode(node, ch);
 
                     if (n is not null)
                     {


### PR DESCRIPTION
Previously, `Character.Any.Char` was assigned to a default value of `'\0'`. This meant that it cannot be differentiated from `new Character('\0')`.

My suggested change is to make `Character.Char` nullable, and base pattern-matching decisions on the nullability instead.

I have added a test to showcase the lack of support for `'\0'` before the change.